### PR TITLE
Use ActiveSupport::Duration to apply time offsets

### DIFF
--- a/delayed_cron.gemspec
+++ b/delayed_cron.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "hashie"
+  s.add_development_dependency "pry-byebug"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/delayed_cron.rb
+++ b/lib/delayed_cron.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'delayed_cron/jobs'
 require 'delayed_cron/scheduling'
 require 'delayed_cron/railtie'

--- a/lib/delayed_cron/cron_job.rb
+++ b/lib/delayed_cron/cron_job.rb
@@ -38,15 +38,15 @@ module DelayedCron
       zone = Time.find_zone!(zone_name)
 
       if hourly?
-        period_in_seconds = 60 * 60
+        period_duration = 1.hour
         scheduled_time_string = "%H:#{scheduled_time_string}"
       else
-        period_in_seconds = 60 * 60 * 24
+        period_duration = 1.day
       end
 
       scheduled_time = zone.now.strftime("%Y-%m-%d #{scheduled_time_string}")
       scheduled_time = zone.parse(scheduled_time)
-      scheduled_time += period_in_seconds if zone.now >= scheduled_time
+      scheduled_time += period_duration while zone.now >= scheduled_time
       scheduled_time.to_i - zone.now.to_i
     end
 


### PR DESCRIPTION
Using seconds to apply the time offsets when the parsed time is in the past is not time zone aware. This causes issues when DST begins/ends between the two times. For example, daily jobs are scheduled an hour earlier than the are supposed to when DST ends since it doesn't take the extra hour into account. This causes further issues when calculating the next offset time, the offset to prevent scheduling past times doesn't apply as expected and the job is scheduled over and over. As a related issue, we sometimes need a two hour jump to bring the parsed time to the future, add a while loop to handle this case.